### PR TITLE
fix: enable service bindings in Redis values.yaml

### DIFF
--- a/create-redis-stack/values.yaml
+++ b/create-redis-stack/values.yaml
@@ -1,5 +1,7 @@
 auth:
   password: ${REDIS_PASSWORD}
+serviceBindings: 
+  enabled: true
 image:
   registry: ghcr.io
   repository: cosmo-tech/cosmotech-redis


### PR DESCRIPTION
Fixation de problème SDCOSMO-1743 :
```
Error: template: redis/templates/replicas/statefulset.yaml:51:28: executing "redis/templates/replicas/statefulset.yaml" at <include (print $.Template.BasePath "/secret.yaml") .>: error calling include: template: redis/templates/secret.yaml:34:14: executing "redis/templates/secret.yaml" at <.Values.serviceBindings.enabled>: nil pointer evaluating interface {}.enabled
│
│   with module.cosmotech-tenant.module.platform-tenant-resources.module.create-redis-stack.helm_release.cosmotechredis,
│   on .terraform/modules/cosmotech-tenant/platform-tenant-resources/create-redis-stack/main.tf line 63, in resource "helm_release" "cosmotechredis":
│   63: resource "helm_release" "cosmotechredis" {
```
les tests :
![image](https://github.com/Cosmo-Tech/terraform-kubernetes-cosmotech-tenant/assets/129797537/b173095a-7423-4653-ae1f-d117637329cc)
![image](https://github.com/Cosmo-Tech/terraform-kubernetes-cosmotech-tenant/assets/129797537/9006189c-ed20-4efc-a054-b10239abc374)

