### PR TITLE
Remove minio

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,6 @@
 | <a name="input_adx_ingestion_uri"></a> [adx\_ingestion\_uri](#input\_adx\_ingestion\_uri) | n/a | `string` | n/a | yes |
 | <a name="input_adx_uri"></a> [adx\_uri](#input\_adx\_uri) | n/a | `string` | n/a | yes |
 | <a name="input_api_dns_name"></a> [api\_dns\_name](#input\_api\_dns\_name) | n/a | `string` | n/a | yes |
-| <a name="input_api_replicas"></a> [api\_replicas](#input\_api\_replicas) | n/a | `number` | n/a | yes |
 | <a name="input_chart_package_version"></a> [chart\_package\_version](#input\_chart\_package\_version) | n/a | `string` | n/a | yes |
 | <a name="input_client_id"></a> [client\_id](#input\_client\_id) | The client id of the app registration used to build this | `string` | n/a | yes |
 | <a name="input_client_secret"></a> [client\_secret](#input\_client\_secret) | The client secret of the app registration used to build this | `string` | n/a | yes |
@@ -68,6 +67,7 @@
 | <a name="input_tenant_resource_group"></a> [tenant\_resource\_group](#input\_tenant\_resource\_group) | n/a | `string` | n/a | yes |
 | <a name="input_tls_certificate_type"></a> [tls\_certificate\_type](#input\_tls\_certificate\_type) | n/a | `any` | n/a | yes |
 | <a name="input_tls_secret_name"></a> [tls\_secret\_name](#input\_tls\_secret\_name) | n/a | `string` | n/a | yes |
+| <a name="input_api_replicas"></a> [api\_replicas](#input\_api\_replicas) | n/a | `number` | `1` | no |
 | <a name="input_archive_ttl"></a> [archive\_ttl](#input\_archive\_ttl) | n/a | `string` | `"3d"` | no |
 | <a name="input_argo_minio_persistence_size"></a> [argo\_minio\_persistence\_size](#input\_argo\_minio\_persistence\_size) | n/a | `string` | `"16Gi"` | no |
 | <a name="input_argo_minio_requests_memory"></a> [argo\_minio\_requests\_memory](#input\_argo\_minio\_requests\_memory) | n/a | `string` | `"2Gi"` | no |
@@ -75,6 +75,8 @@
 | <a name="input_cosmos_key"></a> [cosmos\_key](#input\_cosmos\_key) | n/a | `string` | `""` | no |
 | <a name="input_cosmos_uri"></a> [cosmos\_uri](#input\_cosmos\_uri) | n/a | `string` | `""` | no |
 | <a name="input_cosmotech_api_ingress_enabled"></a> [cosmotech\_api\_ingress\_enabled](#input\_cosmotech\_api\_ingress\_enabled) | n/a | `bool` | `true` | no |
+| <a name="input_cosmotech_api_persistence_size"></a> [cosmotech\_api\_persistence\_size](#input\_cosmotech\_api\_persistence\_size) | n/a | `string` | `"8Gi"` | no |
+| <a name="input_cosmotech_api_persistence_storage_class"></a> [cosmotech\_api\_persistence\_storage\_class](#input\_cosmotech\_api\_persistence\_storage\_class) | n/a | `string` | `""` | no |
 | <a name="input_create_rabbitmq"></a> [create\_rabbitmq](#input\_create\_rabbitmq) | Whether to create RabbitMQ resources | `bool` | `true` | no |
 | <a name="input_list_apikey_allowed"></a> [list\_apikey\_allowed](#input\_list\_apikey\_allowed) | n/a | <pre>list(object({<br>    name           = string<br>    apiKey         = string<br>    associatedRole = string<br>    securedUris    = list(string)<br>  }))</pre> | <pre>[<br>  {<br>    "apiKey": "",<br>    "associatedRole": "",<br>    "name": "",<br>    "securedUris": []<br>  }<br>]</pre> | no |
 | <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | n/a | `bool` | `true` | no |

--- a/create-argo/main.tf
+++ b/create-argo/main.tf
@@ -12,7 +12,7 @@ locals {
     "ARGO_SERVICE_ACCOUNT"        = local.argo_service_account
     "ARGO_BUCKET_NAME"            = var.argo_bucket_name
     "MONITORING_NAMESPACE"        = var.monitoring_namespace
-    "MINIO_RELEASE_NAME"          = local.minio_release_name
+    "MINIO_RELEASE_NAME"          = var.minio_release_name
     "USE_MINIO_STORAGE"           = var.use_minio_storage
     "NAMESPACE"                   = var.namespace
     "POSTGRES_RELEASE_NAME"       = var.postgres_release_name
@@ -22,7 +22,6 @@ locals {
     "ARCHIVE_TTL"                 = var.archive_ttl
   }
   argo_service_account = "argo-workflows-${var.namespace}-service-account"
-  minio_release_name   = "${var.minio_release_name}-${var.namespace}"
 }
 
 locals {

--- a/create-argo/main.tf
+++ b/create-argo/main.tf
@@ -13,6 +13,7 @@ locals {
     "ARGO_BUCKET_NAME"            = var.argo_bucket_name
     "MONITORING_NAMESPACE"        = var.monitoring_namespace
     "MINIO_RELEASE_NAME"          = local.minio_release_name
+    "USE_MINIO_STORAGE"           = var.use_minio_storage
     "NAMESPACE"                   = var.namespace
     "POSTGRES_RELEASE_NAME"       = var.postgres_release_name
     "ARGO_DATABASE"               = var.argo_database

--- a/create-argo/values.yaml
+++ b/create-argo/values.yaml
@@ -17,6 +17,7 @@ executor:
     value: 1s
   - name: WAIT_CONTAINER_STATUS_CHECK_INTERVAL
     value: 1s
+%{ if USE_MINIO_STORAGE }
 useDefaultArtifactRepo: true
 artifactRepository:
   archiveLogs: true
@@ -30,6 +31,7 @@ artifactRepository:
     secretKeySecret:
       name: ${MINIO_RELEASE_NAME}
       key: root-password
+%{ endif }
 server:
   clusterWorkflowTemplates:
     enabled: false

--- a/create-argo/variables.tf
+++ b/create-argo/variables.tf
@@ -35,6 +35,10 @@ variable "minio_release_name" {
   type = string
 }
 
+variable "use_minio_storage" {
+  type = bool
+}
+
 variable "postgres_release_name" {
   type = string
 }

--- a/create-cosmotech-api/main.tf
+++ b/create-cosmotech-api/main.tf
@@ -44,11 +44,9 @@ locals {
     "RABBITMQ_LISTENER_PASSWORD"    = var.rabbitmq_listener_password
     "RABBITMQ_SENDER_USERNAME"      = var.rabbitmq_sender_username
     "RABBITMQ_SENDER_PASSWORD"      = var.rabbitmq_sender_password
-    "S3_ENDPOINT_URL"               = var.s3_endpoint_url
-    "S3_BUCKET_NAME"                = var.s3_bucket_name
-    "S3_ACCESS_KEY_ID"              = var.s3_access_key_id
-    "S3_SECRET_ACCESS_KEY"          = var.s3_secret_access_key
     "ALLOWED_API_KEY_CONSUMERS"     = jsonencode(var.list_apikey_allowed)
+    "PERSISTENCE_SIZE"              = var.persistence_size
+    "PERSISTENCE_STORAGE_CLASS"     = var.persistence_storage_class
   }
   instance_name   = "${var.helm_release_name}-${var.namespace}"
   tls_secret_name = "${var.tls_secret_name}-${var.namespace}"

--- a/create-cosmotech-api/values.yaml
+++ b/create-cosmotech-api/values.yaml
@@ -49,11 +49,6 @@ config:
         workflows:
           namespace: ${NAMESPACE}
           service-account-name: ${ARGO_SERVICE_ACCOUNT}
-      s3:
-        endpointUrl: ${S3_ENDPOINT_URL}
-        bucketName: ${S3_BUCKET_NAME}
-        accessKeyId: ${S3_ACCESS_KEY_ID}
-        secretAccessKey: ${S3_SECRET_ACCESS_KEY}
       authorization:
         allowedApiKeyConsumers: ${ALLOWED_API_KEY_CONSUMERS}
         allowed-tenants: ${TENANT_ID}
@@ -134,6 +129,11 @@ resources:
   requests:
     #   cpu: 100m
     memory: 1024Mi
+
+persistence:
+  enabled: true
+  size: ${PERSISTENCE_SIZE}
+  storageClass: ${PERSISTENCE_STORAGE_CLASS}
 
 tolerations:
 - key: "vendor"

--- a/create-cosmotech-api/variables.tf
+++ b/create-cosmotech-api/variables.tf
@@ -191,22 +191,6 @@ variable "rabbitmq_sender_password" {
   type = string
 }
 
-variable "s3_endpoint_url" {
-  type = string
-}
-
-variable "s3_bucket_name" {
-  type = string
-}
-
-variable "s3_access_key_id" {
-  type = string
-}
-
-variable "s3_secret_access_key" {
-  type = string
-}
-
 variable "list_apikey_allowed" {
   type = list(object({
     name           = string
@@ -223,5 +207,13 @@ variable "list_apikey_allowed" {
 }
 
 variable "identifier_uri" {
+  type = string
+}
+
+variable "persistence_size" {
+  type = string
+}
+
+variable "persistence_storage_class" {
   type = string
 }

--- a/create-minio/main.tf
+++ b/create-minio/main.tf
@@ -2,7 +2,7 @@ locals {
   values_minio = {
     "MONITORING_NAMESPACE"        = var.monitoring_namespace
     "MINIO_RELEASE_NAME"          = local.instance_name
-    "BUCKET_NAMES"                = "${var.argo_bucket_name},${var.cosmotechapi_bucket_name}"
+    "BUCKET_NAMES"                = "${var.argo_bucket_name}"
     "ARGO_MINIO_PERSISTENCE_SIZE" = var.argo_minio_persistence_size
     "ARGO_MINIO_REQUESTS_MEMORY"  = var.argo_minio_requests_memory
     "ARGO_MINIO_ACCESS_KEY"       = var.argo_minio_access_key

--- a/create-minio/main.tf
+++ b/create-minio/main.tf
@@ -11,7 +11,7 @@ locals {
 }
 
 locals {
-  instance_name = "${var.minio_release_name}-${var.namespace}"
+  instance_name = "minio-${var.namespace}"
 }
 
 resource "helm_release" "minio" {

--- a/create-minio/output.tf
+++ b/create-minio/output.tf
@@ -1,0 +1,3 @@
+output "out_minio_release_name" {
+  value = helm_release.minio.metadata.0.name
+}

--- a/create-minio/variables.tf
+++ b/create-minio/variables.tf
@@ -19,10 +19,6 @@ variable "helm_repo_url" {
   default = "https://charts.bitnami.com/bitnami"
 }
 
-variable "minio_release_name" {
-  type = string
-}
-
 variable "helm_chart" {
   type    = string
   default = "minio"

--- a/create-minio/variables.tf
+++ b/create-minio/variables.tf
@@ -47,7 +47,3 @@ variable "argo_minio_requests_memory" {
   type    = string
   default = "2Gi"
 }
-
-variable "cosmotechapi_bucket_name" {
-  type = string
-}

--- a/main.tf
+++ b/main.tf
@@ -1,6 +1,7 @@
 locals {
   tls_secret_name    = var.tls_certificate_type != "none" ? var.tls_secret_name : ""
   minio_release_name = "minio"
+  use_minio_storage  = startswith(var.cosmotech_api_version, "2.") || startswith(var.cosmotech_api_version, "3.")
 }
 
 resource "kubernetes_namespace" "main_namespace" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
-  tls_secret_name             = var.tls_certificate_type != "none" ? var.tls_secret_name : ""
-  minio_release_name          = "minio"
-  cosmotechapi_s3_bucket_name = "cosmotech-api"
+  tls_secret_name    = var.tls_certificate_type != "none" ? var.tls_secret_name : ""
+  minio_release_name = "minio"
 }
 
 resource "kubernetes_namespace" "main_namespace" {

--- a/main.tf
+++ b/main.tf
@@ -1,7 +1,6 @@
 locals {
-  tls_secret_name    = var.tls_certificate_type != "none" ? var.tls_secret_name : ""
-  minio_release_name = "minio"
-  use_minio_storage  = startswith(var.cosmotech_api_version, "2.") || startswith(var.cosmotech_api_version, "3.")
+  tls_secret_name   = var.tls_certificate_type != "none" ? var.tls_secret_name : ""
+  use_minio_storage = startswith(var.cosmotech_api_version, "2.") || startswith(var.cosmotech_api_version, "3.")
 }
 
 resource "kubernetes_namespace" "main_namespace" {

--- a/modules.tf
+++ b/modules.tf
@@ -5,6 +5,7 @@ module "create-argo" {
   monitoring_namespace  = var.monitoring_namespace
   postgres_release_name = module.create-postgresql-db.out_postgres_release_name
   minio_release_name    = local.minio_release_name
+  use_minio_storage     = local.use_minio_storage
 
   depends_on = [
     module.create-postgresql-db
@@ -95,6 +96,7 @@ module "create-cosmotech-api" {
 }
 
 module "create-minio" {
+  count  = local.use_minio_storage ? 1 : 0
   source = "./create-minio"
 
   namespace                   = var.kubernetes_tenant_namespace
@@ -111,7 +113,6 @@ module "create-postgresql-db" {
 
   namespace            = var.kubernetes_tenant_namespace
   monitoring_namespace = var.monitoring_namespace
-  depends_on           = [module.create-minio]
   persistence_size     = var.postgresql_persistence_size
 }
 

--- a/modules.tf
+++ b/modules.tf
@@ -82,12 +82,10 @@ module "create-cosmotech-api" {
   rabbitmq_listener_password    = var.create_rabbitmq ? module.create-rabbitmq.0.out_rabbitmq_listener_password : ""
   rabbitmq_sender_username      = var.create_rabbitmq ? module.create-rabbitmq.0.out_rabbitmq_sender_username : ""
   rabbitmq_sender_password      = var.create_rabbitmq ? module.create-rabbitmq.0.out_rabbitmq_sender_password : ""
-  s3_endpoint_url               = "http://${local.minio_release_name}-${var.kubernetes_tenant_namespace}.${var.kubernetes_tenant_namespace}.svc.cluster.local:9000"
-  s3_bucket_name                = local.cosmotechapi_s3_bucket_name
-  s3_access_key_id              = random_password.argo_minio_access_key.result
-  s3_secret_access_key          = random_password.argo_minio_secret_key.result
   list_apikey_allowed           = var.list_apikey_allowed
   identifier_uri                = var.identifier_uri
+  persistence_size              = var.cosmotech_api_persistence_size
+  persistence_storage_class     = var.cosmotech_api_persistence_storage_class
 
   depends_on = [
     module.create-argo,
@@ -106,7 +104,6 @@ module "create-minio" {
   argo_minio_secret_key       = random_password.argo_minio_secret_key.result
   argo_minio_persistence_size = var.argo_minio_persistence_size
   argo_minio_requests_memory  = var.argo_minio_requests_memory
-  cosmotechapi_bucket_name    = local.cosmotechapi_s3_bucket_name
 }
 
 module "create-postgresql-db" {

--- a/modules.tf
+++ b/modules.tf
@@ -4,7 +4,7 @@ module "create-argo" {
   namespace             = var.kubernetes_tenant_namespace
   monitoring_namespace  = var.monitoring_namespace
   postgres_release_name = module.create-postgresql-db.out_postgres_release_name
-  minio_release_name    = local.minio_release_name
+  minio_release_name    = local.use_minio_storage ? module.create-minio.0.out_minio_release_name : ""
   use_minio_storage     = local.use_minio_storage
 
   depends_on = [
@@ -101,7 +101,6 @@ module "create-minio" {
 
   namespace                   = var.kubernetes_tenant_namespace
   monitoring_namespace        = var.monitoring_namespace
-  minio_release_name          = local.minio_release_name
   argo_minio_access_key       = random_password.argo_minio_access_key.result
   argo_minio_secret_key       = random_password.argo_minio_secret_key.result
   argo_minio_persistence_size = var.argo_minio_persistence_size

--- a/variables.tf
+++ b/variables.tf
@@ -164,6 +164,16 @@ variable "cosmotech_api_ingress_enabled" {
   default = true
 }
 
+variable "cosmotech_api_persistence_size" {
+  type    = string
+  default = "8Gi"
+}
+
+variable "cosmotech_api_persistence_storage_class" {
+  type    = string
+  default = ""
+}
+
 variable "redis_port" {
   type    = number
   default = 6379
@@ -175,7 +185,8 @@ variable "monitoring_enabled" {
 }
 
 variable "api_replicas" {
-  type = number
+  type    = number
+  default = 1
 }
 
 variable "tls_certificate_custom_certificate" {


### PR DESCRIPTION
Topic to discuss before merging:
- Helm chart persistence interface: for now only the size and storage class are exposed and configurable. Do we want the full support of a PVC as done in standard Helm charts (full implicit PVC configuration + PVC reference)?
