### PR TITLE
Enoc/upgrade pod security standard to restricted level

### DIFF
--- a/create-argo/values.yaml
+++ b/create-argo/values.yaml
@@ -54,7 +54,9 @@ server:
   podAnnotations: {}
   podLabels:
     networking/traffic-allowed: "yes"
-  podSecurityContext: {}
+  podSecurityContext:
+    seccompProfile:
+      type: "RuntimeDefault"
   rbac:
     create: true
   securityContext:
@@ -230,7 +232,9 @@ controller:
   podAnnotations: {}
   podLabels:
     networking/traffic-allowed: "yes"
-  podSecurityContext: {}
+  podSecurityContext:
+    seccompProfile:
+      type: "RuntimeDefault"
   metricsConfig:
     enabled: true
     path: /metrics

--- a/create-cosmotech-api/values.yaml
+++ b/create-cosmotech-api/values.yaml
@@ -149,3 +149,16 @@ tolerations:
 
 nodeSelector:
   "cosmotech.com/tier": "services"
+
+podSecurityContext:
+  seccompProfile:
+    type: "RuntimeDefault"
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000

--- a/create-postgresql-db/values.yaml
+++ b/create-postgresql-db/values.yaml
@@ -32,7 +32,6 @@ primary:
   persistence:
     enabled: true
     size: ${PERSISTENCE_SIZE}
-    storageClass: ${STORAGE_CLASS}
   initdb:
     user: postgres
     password: ${POSTGRESQL_PASSWORD}

--- a/create-postgresql-db/values.yaml
+++ b/create-postgresql-db/values.yaml
@@ -7,6 +7,19 @@ auth:
   secretKeys:
     adminPasswordKey: postgres-password
 primary:
+  containerSecurityContext:
+    enabled: true
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
+  podSecurityContext:
+    enabled: true
+    seccompProfile:
+      type: RuntimeDefault
   podLabels:
     "networking/traffic-allowed": "yes"
   tolerations:
@@ -19,6 +32,7 @@ primary:
   persistence:
     enabled: true
     size: ${PERSISTENCE_SIZE}
+    storageClass: ${STORAGE_CLASS}
   initdb:
     user: postgres
     password: ${POSTGRESQL_PASSWORD}
@@ -32,6 +46,12 @@ resources:
     cpu: "1"
 metrics:
   enabled: true
+  containerSecurityContext:
+    enabled: true
+    capabilities:
+      drop:
+        - ALL
+    allowPrivilegeEscalation: false
   serviceMonitor:
     enabled: true
     namespace: ${MONITORING_NAMESPACE}

--- a/create-redis-stack/values.yaml
+++ b/create-redis-stack/values.yaml
@@ -20,6 +20,10 @@ sysctl:
     tag: latest
     pullPolicy: IfNotPresent
 master:
+  podSecurityContext:
+    enabled: true
+  containerSecurityContext:
+    enabled: true
   persistence:
     enabled: true
     size: ${REDIS_DISK_SIZE}
@@ -40,6 +44,10 @@ master:
       cpu: 1000m
       memory: 4Gi
 replica:
+  podSecurityContext:
+    enabled: true
+  containerSecurityContext:
+    enabled: true
   replicaCount: 1
   podLabels:
     networking/traffic-allowed: "yes"


### PR DESCRIPTION
Set the pod policy to restricted by default, following current Pod hardening best practices. 
https://kubernetes.io/docs/concepts/security/pod-security-standards/