### PR TITLE
Increase a bit the acces token lifespan

### DIFF
--- a/create-keycloak-realm/main.tf
+++ b/create-keycloak-realm/main.tf
@@ -11,6 +11,7 @@ resource "keycloak_realm" "realm" {
   realm                       = var.kubernetes_tenant_namespace
   default_signature_algorithm = "RS256"
   enabled                     = true
+  access_token_lifespan       = "30m"
 }
 
 # create web client


### PR DESCRIPTION
The default value is 5 minutes which is a pain when using the API via Swagger for example.
The recommendation is for this value to be lower than the SSO idle timeout which is 30 minutes by default.

We should probably configure all the timeout properly, but for now 30min on the access token should make for a better dev experience